### PR TITLE
Revision package

### DIFF
--- a/app/Exceptions/InvalidRevisionArgumentsException.php
+++ b/app/Exceptions/InvalidRevisionArgumentsException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Exceptions;
+
+
+class InvalidRevisionArgumentsException extends \Exception {
+	
+	/**
+	 * Render the exception into an HTTP response.
+	 *
+	 * @param  \Illuminate\Http\Request
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function render( $request ) {
+		abort( 500, "Internal Server Error: " . $this->getMessage() );
+	}
+}

--- a/app/Exceptions/InvalidRevisionIdException.php
+++ b/app/Exceptions/InvalidRevisionIdException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: cyrillbolliger
+ * Date: 14.10.18
+ * Time: 22:56
+ */
+
+namespace App\Exceptions;
+
+
+class InvalidRevisionIdException extends \Exception {
+	
+	/**
+	 * Render the exception into an HTTP response.
+	 *
+	 * @param  \Illuminate\Http\Request
+	 */
+	public function render( $request ) {
+		abort( 404, "Revision does not exist." );
+	}
+}

--- a/app/Exceptions/RevisionNotFoundException.php
+++ b/app/Exceptions/RevisionNotFoundException.php
@@ -9,7 +9,7 @@
 namespace App\Exceptions;
 
 
-class InvalidRevisionIdException extends \Exception {
+class RevisionNotFoundException extends \Exception {
 	
 	/**
 	 * Render the exception into an HTTP response.

--- a/app/Repository/Member/MemberRepository.php
+++ b/app/Repository/Member/MemberRepository.php
@@ -11,6 +11,7 @@ namespace App\Repository\Member;
 
 
 use App\Exceptions\InvalidFixedValueException;
+use App\Exceptions\InvalidRevisionIdException;
 use App\Exceptions\MemberNotFoundException;
 use App\Exceptions\MemberUnknownFieldException;
 use App\Exceptions\MultiSelectOverwriteException;
@@ -19,9 +20,16 @@ use App\Exceptions\WeblingAPIException;
 use App\Exceptions\WeblingFieldMappingConfigException;
 use App\Repository\Member\Field\Field;
 use App\Repository\Repository;
+use App\Repository\Revision\RevisionRepository;
 use Webling\API\ClientException;
 
 class MemberRepository extends Repository {
+	/**
+	 * The maximum of members that should be queried in one turn.
+	 *
+	 * If more members are queried, it is split up in multiple requests.
+	 */
+	const QUERY_MEMBER_MAX = 100;
 	
 	/**
 	 * Find the master record of a given member (or member id)
@@ -41,10 +49,122 @@ class MemberRepository extends Repository {
 	 *
 	 * @return Member[]
 	 *
+	 * @throws ClientException
+	 * @throws InvalidFixedValueException
+	 * @throws InvalidRevisionIdException
+	 * @throws MemberNotFoundException
+	 * @throws MemberUnknownFieldException
+	 * @throws MultiSelectOverwriteException
+	 * @throws ValueTypeException
+	 * @throws WeblingAPIException
+	 * @throws WeblingFieldMappingConfigException
+	 *
 	 * @see https://gruenesandbox.webling.ch/api#replicate
 	 */
 	public function getUpdated( int $revisionId ): array {
+		$repository = new RevisionRepository( $this->api_key, $this->api_url );
+		$revision   = $repository->get( $revisionId );
+		
+		return $this->getMultiple( $revision->getMemberIds() );
+	}
+	
+	/**
+	 * Get multiple members by id.
+	 *
+	 * If more than self::QUERY_MEMBER_MAX ids are queried, Webling ist queried
+	 * multiple times with at most members self::QUERY_MEMBER_MAX per request.
+	 *
+	 * @param array $memberIds
+	 *
+	 * @return Member[]
+	 *
+	 * @throws ClientException
+	 * @throws InvalidFixedValueException
+	 * @throws MemberNotFoundException
+	 * @throws MemberUnknownFieldException
+	 * @throws MultiSelectOverwriteException
+	 * @throws ValueTypeException
+	 * @throws WeblingAPIException
+	 * @throws WeblingFieldMappingConfigException
+	 */
+	private function getMultiple( array $memberIds ): array {
+		$blocks = array_chunk( $memberIds, self::QUERY_MEMBER_MAX );
+		
+		$members = [];
+		foreach ( $blocks as $block ) {
+			$ids = implode( ',', $block );
+			
+			$resp = $this->apiGet( "member/$ids" );
+			
+			if ( $resp->getStatusCode() === 200 ) {
+				$newMembers = $this->getMembersFromWeblingPayload( $resp->getData(), $block );
+				$members    += $newMembers;
+			} else if ( $resp->getStatusCode() === 404 ) {
+				throw new MemberNotFoundException();
+			} else {
+				throw new WeblingAPIException( "Get request to Webling failed with status code {$resp->getStatusCode()}" );
+			}
+		}
+		
+		return $members;
+	}
+	
+	/**
+	 * Convert the payload of a webling member response into an array of members
+	 *
+	 * @param array $payload the data from the Webling response
+	 * @param int[] $ids the webling ids that were requested
+	 *
+	 * @return Member[] with the webling ids as key and the member as value
+	 *
+	 * @throws InvalidFixedValueException
+	 * @throws MemberUnknownFieldException
+	 * @throws MultiSelectOverwriteException
+	 * @throws ValueTypeException
+	 * @throws WeblingFieldMappingConfigException
+	 */
+	private function getMembersFromWeblingPayload( array $payload, array $ids ): array {
+		/*
+		 * Normalize webling payload
+		 *
+		 * Put single member response payload into array, so it has the same
+		 * form as a multi member response payload.
+		 */
+		if ( 1 === count( $ids ) ) {
+			$payload['id'] = $ids[0];
+			$payload       = [ $payload ];
+		}
+		
+		$members = [];
+		foreach ( $payload as $memberData ) {
+			$fieldData = $memberData['properties'];
+			$groups    = $this->getGroups( $memberData['parents'] );
+			$id        = $memberData['id'];
+			
+			$members[ $id ] = new Member( $fieldData, $id, $groups, true );
+		}
+		
+		return $members;
+	}
+	
+	/**
+	 * Convert group ids in array into Groups
+	 *
+	 * @param int[] $groupIds
+	 *
+	 * @return Group[]
+	 */
+	private function getGroups( array $groupIds ): array {
 		// todo: implement this
+		return [ 100 ]; // todo: remove this mock
+//		$groupRepository = new GroupRepository();
+//
+//		$groups = [];
+//		foreach ( $groupIds as $groupId ) {
+//			$groups[] = $groupRepository->get( $groupId );
+//		}
+//
+//		return $groups;
 	}
 	
 	/**
@@ -160,41 +280,9 @@ class MemberRepository extends Repository {
 	 * @see https://gruenesandbox.webling.ch/api#header-error-status-codes
 	 */
 	public function get( int $id ): Member {
-		$data = $this->apiGet( "member/$id" );
+		$result = $this->getMultiple( [ $id ] );
 		
-		if ( $data->getStatusCode() === 200 ) {
-			$memberData = $data->getData();
-			$fieldData  = $memberData['properties'];
-			$groups     = $this->getGroups( $memberData['parents'] );
-			
-			return new Member( $fieldData, $id, $groups, true );
-		}
-		
-		if ( $data->getStatusCode() === 404 ) {
-			throw new MemberNotFoundException();
-		} else {
-			throw new WeblingAPIException( "Get request to Webling failed with status code {$data->getStatusCode()}" );
-		}
-	}
-	
-	/**
-	 * Convert group ids in array into Groups
-	 *
-	 * @param int[] $groupIds
-	 *
-	 * @return Group[]
-	 */
-	private function getGroups( array $groupIds ): array {
-		// todo: implement this
-		return [ 100 ]; // todo: remove this mock
-//		$groupRepository = new GroupRepository();
-//
-//		$groups = [];
-//		foreach ( $groupIds as $groupId ) {
-//			$groups[] = $groupRepository->get( $groupId );
-//		}
-//
-//		return $groups;
+		return array_pop( $result );
 	}
 	
 	/**

--- a/app/Repository/Member/MemberRepository.php
+++ b/app/Repository/Member/MemberRepository.php
@@ -11,10 +11,11 @@ namespace App\Repository\Member;
 
 
 use App\Exceptions\InvalidFixedValueException;
-use App\Exceptions\InvalidRevisionIdException;
+use App\Exceptions\InvalidRevisionArgumentsException;
 use App\Exceptions\MemberNotFoundException;
 use App\Exceptions\MemberUnknownFieldException;
 use App\Exceptions\MultiSelectOverwriteException;
+use App\Exceptions\RevisionNotFoundException;
 use App\Exceptions\ValueTypeException;
 use App\Exceptions\WeblingAPIException;
 use App\Exceptions\WeblingFieldMappingConfigException;
@@ -52,13 +53,14 @@ class MemberRepository extends Repository {
 	 *
 	 * @throws ClientException
 	 * @throws InvalidFixedValueException
-	 * @throws InvalidRevisionIdException
+	 * @throws RevisionNotFoundException
 	 * @throws MemberNotFoundException
 	 * @throws MemberUnknownFieldException
 	 * @throws MultiSelectOverwriteException
 	 * @throws ValueTypeException
 	 * @throws WeblingAPIException
 	 * @throws WeblingFieldMappingConfigException
+	 * @throws InvalidRevisionArgumentsException
 	 *
 	 * @see https://gruenesandbox.webling.ch/api#replicate
 	 */

--- a/app/Repository/Member/MemberRepository.php
+++ b/app/Repository/Member/MemberRepository.php
@@ -66,6 +66,8 @@ class MemberRepository extends Repository {
 		$repository = new RevisionRepository( $this->api_key, $this->api_url );
 		$revision   = $repository->get( $revisionId );
 		
+		// todo: timeout handling
+		
 		return $this->getMultiple( $revision->getMemberIds() );
 	}
 	

--- a/app/Repository/Repository.php
+++ b/app/Repository/Repository.php
@@ -12,7 +12,32 @@ namespace App\Repository;
 use Webling\API\Client;
 
 abstract class Repository {
+	/**
+	 * The Webling client object
+	 *
+	 * @see https://github.com/usystems/webling-api-php
+	 *
+	 * @var Client
+	 */
 	private $webling_client;
+	
+	/**
+	 * The api key
+	 *
+	 * Exposed to child classes, so they can instantiate further repositories.
+	 *
+	 * @var string
+	 */
+	protected $api_key;
+	
+	/**
+	 * The api url
+	 *
+	 * Exposed to child classes, so they can instantiate further repositories.
+	 *
+	 * @var string
+	 */
+	protected $api_url;
 	
 	/**
 	 * Repository constructor.
@@ -28,6 +53,9 @@ abstract class Repository {
 		if ( ! $api_url ) {
 			$api_url = config( 'app.webling_base_url' );
 		}
+		
+		$this->api_key = $api_key;
+		$this->api_url = $api_url;
 		
 		$this->webling_client = new Client( $api_url, $api_key );
 	}

--- a/app/Repository/Revision/Revision.php
+++ b/app/Repository/Revision/Revision.php
@@ -9,6 +9,8 @@
 namespace App\Repository\Revision;
 
 
+use App\Exceptions\InvalidRevisionArgumentsException;
+
 class Revision {
 	/**
 	 * The webling ids of the members, where some member properties have
@@ -38,12 +40,18 @@ class Revision {
 	 * @param int $queriedRevisionId
 	 * @param int $currentRevisionId
 	 * @param int[] $memberIds
+	 *
+	 * @throws InvalidRevisionArgumentsException
 	 */
 	public function __construct(
 		int $queriedRevisionId,
 		int $currentRevisionId,
 		array $memberIds
 	) {
+		if ( $queriedRevisionId > $currentRevisionId ) {
+			throw new InvalidRevisionArgumentsException( 'The queried revision id must not exceed the current revision id.' );
+		}
+		
 		$this->memberIds         = $memberIds;
 		$this->currentRevisionId = $currentRevisionId;
 		$this->queriedRevisionId = $queriedRevisionId;

--- a/app/Repository/Revision/Revision.php
+++ b/app/Repository/Revision/Revision.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: cyrillbolliger
+ * Date: 30.11.18
+ * Time: 17:32
+ */
+
+namespace App\Repository\Revision;
+
+
+class Revision {
+	/**
+	 * The webling ids of the members, where some member properties have
+	 * changed between the queried revision and the current revision.
+	 *
+	 * @var int[]
+	 */
+	private $memberIds;
+	
+	/**
+	 * The most recent revision id
+	 *
+	 * @var int
+	 */
+	private $currentRevisionId;
+	
+	/**
+	 * The revision id that was used to get the member ids
+	 *
+	 * @var int
+	 */
+	private $queriedRevisionId;
+	
+	/**
+	 * Revision constructor.
+	 *
+	 * @param int $queriedRevisionId
+	 * @param int $currentRevisionId
+	 * @param int[] $memberIds
+	 */
+	public function __construct(
+		int $queriedRevisionId,
+		int $currentRevisionId,
+		array $memberIds
+	) {
+		$this->memberIds         = $memberIds;
+		$this->currentRevisionId = $currentRevisionId;
+		$this->queriedRevisionId = $queriedRevisionId;
+	}
+	
+	/**
+	 * @return int[]
+	 */
+	public function getMemberIds(): array {
+		return $this->memberIds;
+	}
+	
+	/**
+	 * @return int
+	 */
+	public function getCurrentRevisionId(): int {
+		return $this->currentRevisionId;
+	}
+	
+	/**
+	 * @return int
+	 */
+	public function getQueriedRevisionId(): int {
+		return $this->queriedRevisionId;
+	}
+}

--- a/app/Repository/Revision/RevisionRepository.php
+++ b/app/Repository/Revision/RevisionRepository.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: cyrillbolliger
+ * Date: 30.11.18
+ * Time: 17:31
+ */
+
+namespace App\Repository\Revision;
+
+
+use App\Exceptions\InvalidRevisionIdException;
+use App\Exceptions\WeblingAPIException;
+use App\Repository\Repository;
+
+class RevisionRepository extends Repository {
+	
+	/**
+	 * Return revision form given id.
+	 *
+	 * @param int $revisionId
+	 *
+	 * @return Revision
+	 * @throws InvalidRevisionIdException
+	 * @throws WeblingAPIException
+	 * @throws \Webling\API\ClientException
+	 */
+	public function get( int $revisionId ): Revision {
+		$resp = $this->apiGet( "replicate/$revisionId" );
+		
+		if ( $resp->getStatusCode() !== 200 ) {
+			throw new WeblingAPIException( "Get request to Webling failed with status code {$resp->getStatusCode()}" );
+		}
+		
+		$data            = $resp->getData();
+		$currentRevision = $data['revision'];
+		
+		if ( 0 >= $currentRevision ) {
+			throw new InvalidRevisionIdException( "Webling didn't find a revision with the id {$revisionId}" );
+		}
+		
+		$memberIds = ! empty( $data['objects']['member'] ) ? $data['objects']['member'] : [];
+		
+		return new Revision(
+			$revisionId,
+			$currentRevision,
+			$memberIds
+		);
+	}
+	
+	/**
+	 * Return the latest revision id of Webling.
+	 *
+	 * @return int
+	 * @throws WeblingAPIException
+	 * @throws \Webling\API\ClientException
+	 */
+	public function getCurrentRevisionId(): int {
+		$resp = $this->apiGet( "replicate" );
+		
+		if ( $resp->getStatusCode() !== 200 ) {
+			throw new WeblingAPIException( "Get request to Webling failed with status code {$resp->getStatusCode()}" );
+		}
+		
+		return $resp->getData()['revision'];
+	}
+}

--- a/app/Repository/Revision/RevisionRepository.php
+++ b/app/Repository/Revision/RevisionRepository.php
@@ -9,7 +9,8 @@
 namespace App\Repository\Revision;
 
 
-use App\Exceptions\InvalidRevisionIdException;
+use App\Exceptions\InvalidRevisionArgumentsException;
+use App\Exceptions\RevisionNotFoundException;
 use App\Exceptions\WeblingAPIException;
 use App\Repository\Repository;
 
@@ -21,9 +22,10 @@ class RevisionRepository extends Repository {
 	 * @param int $revisionId
 	 *
 	 * @return Revision
-	 * @throws InvalidRevisionIdException
+	 * @throws RevisionNotFoundException
 	 * @throws WeblingAPIException
 	 * @throws \Webling\API\ClientException
+	 * @throws InvalidRevisionArgumentsException
 	 */
 	public function get( int $revisionId ): Revision {
 		$resp = $this->apiGet( "replicate/$revisionId" );
@@ -36,7 +38,7 @@ class RevisionRepository extends Repository {
 		$currentRevision = $data['revision'];
 		
 		if ( 0 >= $currentRevision ) {
-			throw new InvalidRevisionIdException( "Webling didn't find a revision with the id {$revisionId}" );
+			throw new RevisionNotFoundException( "Webling didn't find a revision with the id {$revisionId}" );
 		}
 		
 		$memberIds = ! empty( $data['objects']['member'] ) ? $data['objects']['member'] : [];

--- a/tests/Unit/Repository/Member/MemberRepositoryTest.php
+++ b/tests/Unit/Repository/Member/MemberRepositoryTest.php
@@ -116,7 +116,7 @@ class MemberRepositoryTest extends TestCase {
 		/** @noinspection PhpUnhandledExceptionInspection */
 		$updated = $this->repository->getUpdated( self::REVISION_ID );
 		foreach ( $updated as $member ) {
-			$this->assertTrue( $member instanceof Member );
+			$this->assertTrue( $member instanceof Member || null === $member );
 		}
 		
 		/** @noinspection PhpUnhandledExceptionInspection */

--- a/tests/Unit/Repository/Member/MemberRepositoryTest.php
+++ b/tests/Unit/Repository/Member/MemberRepositoryTest.php
@@ -10,9 +10,12 @@ namespace App\Repository\Member;
 
 
 use App\Exceptions\MemberNotFoundException;
+use App\Repository\Revision\RevisionRepository;
 use Tests\TestCase;
 
 class MemberRepositoryTest extends TestCase {
+	const REVISION_ID = 2000;
+	
 	/**
 	 * @var MemberRepository
 	 */
@@ -110,8 +113,18 @@ class MemberRepositoryTest extends TestCase {
 	}
 	
 	public function testGetUpdated() {
-		// todo: implement this
-		$this->assertTrue( true );
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$updated = $this->repository->getUpdated( self::REVISION_ID );
+		foreach ( $updated as $member ) {
+			$this->assertTrue( $member instanceof Member );
+		}
+		
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$rervisionRepository = new RevisionRepository( config( 'app.webling_api_key' ) );
+		$revision            = $rervisionRepository->get( self::REVISION_ID );
+		foreach ( $revision->getMemberIds() as $id ) {
+			$this->assertTrue( array_key_exists( $id, $updated ) );
+		}
 	}
 	
 	public function testFind() {

--- a/tests/Unit/Repository/Revision/RevisionRepositoryTest.php
+++ b/tests/Unit/Repository/Revision/RevisionRepositoryTest.php
@@ -10,12 +10,14 @@
 namespace App\Repository\Revision;
 
 
-use App\Exceptions\InvalidRevisionIdException;
+use App\Exceptions\InvalidRevisionArgumentsException;
+use App\Exceptions\RevisionNotFoundException;
 use Tests\TestCase;
 
 class RevisionRepositoryTest extends TestCase {
 	const INVALID_REVISION_ID = 0;
 	const VALID_REVISION_ID = 2000;
+	const EXCEEDING_REVISION_ID = 1000000;
 	
 	/**
 	 * @var RevisionRepository
@@ -37,9 +39,14 @@ class RevisionRepositoryTest extends TestCase {
 		$this->assertTrue( is_int( $revision->getMemberIds()[0] ) );
 	}
 	
-	public function testGet__InvalidRevisionIdException() {
-		$this->expectException( InvalidRevisionIdException::class );
+	public function testGet__RevisionNotFoundException() {
+		$this->expectException( RevisionNotFoundException::class );
 		$this->repository->get( self::INVALID_REVISION_ID );
+	}
+	
+	public function testGet__InvalidRevisionArgumentsException() {
+		$this->expectException( InvalidRevisionArgumentsException::class );
+		$this->repository->get( self::EXCEEDING_REVISION_ID );
 	}
 	
 	public function testGetCurrentRevisionId() {

--- a/tests/Unit/Repository/Revision/RevisionRepositoryTest.php
+++ b/tests/Unit/Repository/Revision/RevisionRepositoryTest.php
@@ -1,0 +1,50 @@
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
+/**
+ * Created by PhpStorm.
+ * User: cyrillbolliger
+ * Date: 30.11.18
+ * Time: 18:21
+ */
+
+namespace App\Repository\Revision;
+
+
+use App\Exceptions\InvalidRevisionIdException;
+use Tests\TestCase;
+
+class RevisionRepositoryTest extends TestCase {
+	const INVALID_REVISION_ID = 0;
+	const VALID_REVISION_ID = 2000;
+	
+	/**
+	 * @var RevisionRepository
+	 */
+	private $repository;
+	
+	public function setUp() {
+		parent::setUp();
+		
+		$this->repository = new RevisionRepository( config( 'app.webling_api_key' ) );
+	}
+	
+	public function testGet() {
+		$revision = $this->repository->get( self::VALID_REVISION_ID );
+		
+		$this->assertEquals( self::VALID_REVISION_ID, $revision->getQueriedRevisionId() );
+		$this->assertGreaterThan( self::VALID_REVISION_ID, $revision->getCurrentRevisionId() );
+		$this->assertNotEmpty( $revision->getMemberIds() );
+		$this->assertTrue( is_int( $revision->getMemberIds()[0] ) );
+	}
+	
+	public function testGet__InvalidRevisionIdException() {
+		$this->expectException( InvalidRevisionIdException::class );
+		$this->repository->get( self::INVALID_REVISION_ID );
+	}
+	
+	public function testGetCurrentRevisionId() {
+		$revisionId = $this->repository->getCurrentRevisionId();
+		$this->assertTrue( is_int( $revisionId ) );
+		$this->assertGreaterThan( self::VALID_REVISION_ID, $revisionId );
+	}
+}

--- a/tests/Unit/Repository/Revision/RevisionRepositoryTest.php
+++ b/tests/Unit/Repository/Revision/RevisionRepositoryTest.php
@@ -16,8 +16,8 @@ use Tests\TestCase;
 
 class RevisionRepositoryTest extends TestCase {
 	const INVALID_REVISION_ID = 0;
-	const VALID_REVISION_ID = 2000;
 	const EXCEEDING_REVISION_ID = 1000000;
+	const REVISION_LAG = 100;
 	
 	/**
 	 * @var RevisionRepository
@@ -31,10 +31,11 @@ class RevisionRepositoryTest extends TestCase {
 	}
 	
 	public function testGet() {
-		$revision = $this->repository->get( self::VALID_REVISION_ID );
+		$revisionId = $this->repository->getCurrentRevisionId() - self::REVISION_LAG;
+		$revision   = $this->repository->get( $revisionId );
 		
-		$this->assertEquals( self::VALID_REVISION_ID, $revision->getQueriedRevisionId() );
-		$this->assertGreaterThan( self::VALID_REVISION_ID, $revision->getCurrentRevisionId() );
+		$this->assertEquals( $revisionId, $revision->getQueriedRevisionId() );
+		$this->assertGreaterThan( $revisionId, $revision->getCurrentRevisionId() );
 		$this->assertNotEmpty( $revision->getMemberIds() );
 		$this->assertTrue( is_int( $revision->getMemberIds()[0] ) );
 	}
@@ -52,6 +53,5 @@ class RevisionRepositoryTest extends TestCase {
 	public function testGetCurrentRevisionId() {
 		$revisionId = $this->repository->getCurrentRevisionId();
 		$this->assertTrue( is_int( $revisionId ) );
-		$this->assertGreaterThan( self::VALID_REVISION_ID, $revisionId );
 	}
 }


### PR DESCRIPTION
Habe mal das Revision Package zu implementieren versucht.

Betreffend Timout-handling müssen wir uns aber noch etwas einfallen lassen. Das Problem ist das Folgende: Wenn `getUpdated` zu lange braucht, killt Apache gleich den ganzen Thread. Theoretisch könnten wir, kurz davor stoppen und die Resultate zwischenspeichern. Die Frage ist, wie wir den Thread danach neu starten?
Die einzige Möglichkeit, die mir eingefallen ist, wäre, die bereits abgeholten Resultate kurz vor Ablauf des Timeouts per API zurückzusenden und zusätzlich eine Metainformation in die Response zu packen, dass der Request so lange wiederholen sei, bis alle Resultate abgeholt wurden. Gerade elegant ist das aber nicht. Vielleicht hat jemand von euch eine bessere Idee?