### PR TITLE
Update modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 /public/hot
 /public/storage
 /storage/*.key
+/storage/cache
 /public/css
 /public/js
 /vendor

--- a/app/Exceptions/WeblingAPIException.php
+++ b/app/Exceptions/WeblingAPIException.php
@@ -11,13 +11,14 @@ namespace App\Exceptions;
 
 class WeblingAPIException extends \Exception {
 
-  /**
-   * Render the exception into an HTTP response.
-   *
-   * @param  \Illuminate\Http\Request
-   * @return \Illuminate\Http\Response
-   */
-  public function render($request) {
-      abort(500, "Internal Server Error: " . $this->getMessage());
-  }
+	/**
+	 * Render the exception into an HTTP response.
+	 *
+	 * @param \Illuminate\Http\Request
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function render( $request ) {
+		abort( $this->getCode(), "Remote API Error: " . $this->getMessage() );
+	}
 }

--- a/app/Http/Controllers/RestApi/RestApiMember.php
+++ b/app/Http/Controllers/RestApi/RestApiMember.php
@@ -294,8 +294,8 @@ class RestApiMember {
 				$field['mode'] = self::MODE_REPLACE;
 			}
 
-			if ( ! is_array( $field ) || ! isset( $field['mode'] ) || ! isset( $field['value'] ) ) {
-				throw new BadRequestException( 'Malformed "member" data.' );
+			if ( ! is_array( $field ) || ! array_key_exists( 'mode', $field ) || ! array_key_exists( 'value', $field ) ) {
+				throw new BadRequestException( 'Malformed data in field: ' . $fieldKey );
 			}
 
 			if ( Member::KEY_GROUPS === $fieldKey ) {

--- a/app/Http/Controllers/RestApi/RestApiMember.php
+++ b/app/Http/Controllers/RestApi/RestApiMember.php
@@ -396,12 +396,11 @@ class RestApiMember {
 	private function patchField( Member &$member, array $data, string $key ) {
 		$mode = $data['mode'];
 
-		if ( self::MODE_APPEND === $mode && ! method_exists( $member->$key, 'append' ) ) {
-			throw new IllegalFieldUpdateMode( "The update mode '{$data['mode']}' for the field '$key' is not supported." );
-		}
-
 		switch ( $mode ) {
 			case self::MODE_APPEND:
+				if ( ! method_exists( $member->$key, 'append' ) ) {
+					throw new IllegalFieldUpdateMode( "The update mode '{$data['mode']}' for the field '$key' is not supported." );
+				}
 				$member->$key->append( $data['value'] );
 				break;
 

--- a/app/Http/Controllers/RestApi/RestApiMember.php
+++ b/app/Http/Controllers/RestApi/RestApiMember.php
@@ -319,11 +319,11 @@ class RestApiMember {
 	private function extractMemberData( Request &$request ): array {
 		$memberData = json_decode( $request->getContent(), true );
 		if ( ! $memberData ) {
-			throw new BadRequestException( 'Missing or invalid "member" field in request data.' );
+			throw new BadRequestException( 'Missing request content data.' );
 		}
 
 		if ( ! is_array( $memberData ) ) {
-			throw new BadRequestException( 'Malformed "member" data.' );
+			throw new BadRequestException( 'Malformed member data.' );
 		}
 
 		return $memberData;

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,7 +38,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:60,1',
+            'throttle:200,1',
             'bindings',
 	        'client',
 	        \App\Http\Middleware\AddAllowedRootGroups::class,

--- a/app/Repository/Member/Field/FreeField.php
+++ b/app/Repository/Member/Field/FreeField.php
@@ -20,7 +20,7 @@ abstract class FreeField extends Field {
 		$this->weblingKey = $weblingKey;
 		$this->setValue( $value, false );
 	}
-	
+
 	/**
 	 * @param string|null $value
 	 * @param boolean $dirty
@@ -30,17 +30,30 @@ abstract class FreeField extends Field {
 	public function setValue( $value, bool $dirty = true ) {
 		$this->assertOptionalStringType( $value );
 		$value = self::clean( $value );
-		
+
 		if ( $value !== $this->getValue() ) {
 			$this->value = $value;
 			$this->setDirty( $dirty );
 		}
 	}
-	
+
 	/**
 	 * @return string|array
 	 */
 	public function getWeblingValue() {
 		return $this->getValue();
+	}
+
+	/**
+	 * Check if the given needle is contained in the value.
+	 *
+	 * Returns only true, if the match is bounded, not if it is in the middle of a word.
+	 *
+	 * @param string $needle
+	 *
+	 * @return bool
+	 */
+	protected function inValue( string $needle ) {
+		return 1 === preg_match( "/\b$needle\b/", $this->getValue() );
 	}
 }

--- a/app/Repository/Member/Field/LongTextField.php
+++ b/app/Repository/Member/Field/LongTextField.php
@@ -9,5 +9,21 @@
 namespace App\Repository\Member\Field;
 
 class LongTextField extends FreeField {
+	/**
+	 * Append value, if it's not already in the the field.
+	 *
+	 * @param $value
+	 * @param bool $dirty
+	 * @param string $separator
+	 *
+	 * @throws \App\Exceptions\ValueTypeException
+	 */
+	public function append( $value, bool $dirty = true, string $separator = "\n" ) {
+		if ( ! $value || $this->inValue( $value ) ) {
+			return;
+		}
 
+		$v = $this->getValue() . $separator . $value;
+		$this->setValue( $v, $dirty );
+	}
 }

--- a/app/Repository/Member/Field/LongTextField.php
+++ b/app/Repository/Member/Field/LongTextField.php
@@ -23,7 +23,12 @@ class LongTextField extends FreeField {
 			return;
 		}
 
-		$v = $this->getValue() . $separator . $value;
+		if ( empty( $this->getValue() ) ) {
+			$v = $value;
+		} else {
+			$v = $this->getValue() . $separator . $value;
+		}
+
 		$this->setValue( $v, $dirty );
 	}
 }

--- a/app/Repository/Member/Field/MultiSelectField.php
+++ b/app/Repository/Member/Field/MultiSelectField.php
@@ -20,7 +20,7 @@ class MultiSelectField extends FixedField {
 		$this->possibleValues = $possibleValues;
 		$this->value          = array();
 	}
-	
+
 	/**
 	 * Remove the given element(s)
 	 *
@@ -31,11 +31,11 @@ class MultiSelectField extends FixedField {
 	 */
 	public function remove( $values, bool $dirty = true ) {
 		$new = (array) $values;
-		
+
 		foreach ( $new as &$value ) {
 			$value = $this->clean( $value );
 			$value = $this->makeInternalValue( $value );
-			
+
 			if ( $this->hasValue( $value ) && null !== $value ) {
 				$key = array_search( $value, $this->value );
 				unset( $this->value[ $key ] );
@@ -43,7 +43,7 @@ class MultiSelectField extends FixedField {
 			}
 		}
 	}
-	
+
 	/**
 	 * Check if value is set
 	 *
@@ -53,7 +53,7 @@ class MultiSelectField extends FixedField {
 	 */
 	public function hasValue( string $value ): bool {
 		$value = $this->clean( $value );
-		
+
 		if ( null !== $value ) {
 			try {
 				$value = $this->makeInternalValue( $value );
@@ -61,10 +61,10 @@ class MultiSelectField extends FixedField {
 				return false;
 			}
 		}
-		
+
 		return in_array( $value, $this->getValue() );
 	}
-	
+
 	/**
 	 * Set the given values
 	 *
@@ -77,16 +77,16 @@ class MultiSelectField extends FixedField {
 		if ( empty( $values ) && ! empty( $this->value ) ) {
 			$this->value = array();
 			$this->setDirty( $dirty );
-			
+
 			return;
 		}
-		
+
 		$values = (array) $values;
-		
+
 		foreach ( $values as &$value ) {
 			$value = self::clean( $value );
 			$value = $this->makeInternalValue( $value );
-			
+
 			if ( ! $this->hasValue( $value ) && null !== $value ) {
 				$this->value = array();
 				$this->append( $values, $dirty );
@@ -94,7 +94,7 @@ class MultiSelectField extends FixedField {
 			}
 		}
 	}
-	
+
 	/**
 	 * Append an array of values or a single value given as string
 	 *
@@ -104,19 +104,23 @@ class MultiSelectField extends FixedField {
 	 * @throws InvalidFixedValueException
 	 */
 	public function append( $values, bool $dirty = true ) {
+		if ( null === $values || [] === $values || '' === $values || false === $values ) {
+			return;
+		}
+
 		$new = (array) $values;
-		
+
 		foreach ( $new as &$value ) {
 			$value = $this->clean( $value );
 			$value = $this->makeInternalValue( $value );
-			
+
 			if ( ! $this->hasValue( $value ) && null !== $value ) {
 				array_push( $this->value, $value );
 				$this->setDirty( $dirty );
 			}
 		}
 	}
-	
+
 	/**
 	 * Return the webling values
 	 *
@@ -127,7 +131,7 @@ class MultiSelectField extends FixedField {
 		foreach ( $this->getValue() as $value ) {
 			$array[] = $this->possibleValues[ $value ];
 		}
-		
+
 		return $array;
 	}
 }

--- a/app/Repository/Member/Field/TextField.php
+++ b/app/Repository/Member/Field/TextField.php
@@ -44,7 +44,12 @@ class TextField extends FreeField {
 			return;
 		}
 
-		$v = $this->getValue() . $separator . $value;
+		if ( empty( $this->getValue() ) ) {
+			$v = $value;
+		} else {
+			$v = $this->getValue() . $separator . $value;
+		}
+
 		$this->setValue( $v, $dirty );
 	}
 }

--- a/app/Repository/Member/Field/TextField.php
+++ b/app/Repository/Member/Field/TextField.php
@@ -9,7 +9,7 @@ use App\Exceptions\ValueTypeException;
 
 class TextField extends FreeField {
 	const MAX_LEN = 255;
-	
+
 	/**
 	 * Make sure we don't exceed the length limit
 	 *
@@ -21,11 +21,30 @@ class TextField extends FreeField {
 	 */
 	public function setValue( $value, bool $dirty = true ) {
 		$this->assertOptionalStringType( $value );
-		
+
 		if ( null !== $value && self::MAX_LEN < strlen( $value ) ) {
 			throw new InputLengthException( 'Max length of input (' . self::MAX_LEN . ' characters) exceeded' );
 		}
-		
+
 		parent::setValue( $value, $dirty );
+	}
+
+	/**
+	 * Append value, if it's not already in the the field.
+	 *
+	 * @param $value
+	 * @param bool $dirty
+	 * @param string $separator
+	 *
+	 * @throws InputLengthException
+	 * @throws ValueTypeException
+	 */
+	public function append( $value, bool $dirty = true, string $separator = ', ' ) {
+		if ( ! $value || $this->inValue( $value ) ) {
+			return;
+		}
+
+		$v = $this->getValue() . $separator . $value;
+		$this->setValue( $v, $dirty );
 	}
 }

--- a/app/Repository/Member/MemberRepository.php
+++ b/app/Repository/Member/MemberRepository.php
@@ -249,7 +249,7 @@ class MemberRepository extends Repository {
 				$newMembers                 = $this->getMultiple( $block, $recursiveMembersPerRequest );
 				$members                    += $newMembers;
 			} else {
-				throw new WeblingAPIException( "Get request to Webling failed with status code {$resp->getStatusCode()}" );
+				throw new WeblingAPIException( "Get request to Webling failed: {$resp->getRawData()}", $resp->getStatusCode() );
 			}
 		}
 
@@ -370,7 +370,7 @@ class MemberRepository extends Repository {
 			if ( $data ) { // only send request, if data has changed
 				$resp = $this->apiPut( "member/$id", $data );
 				if ( $resp->getStatusCode() !== 204 ) {
-					throw new WeblingAPIException( "Put request to Webling failed with status code {$resp->getStatusCode()}" );
+					throw new WeblingAPIException( "Put request to Webling failed: {$resp->getRawData()}", $resp->getStatusCode() );
 				}
 			}
 
@@ -378,7 +378,7 @@ class MemberRepository extends Repository {
 			// create
 			$resp = $this->apiPost( 'member', $data );
 			if ( $resp->getStatusCode() !== 201 ) {
-				throw new WeblingAPIException( "Post request to Webling failed with status code {$resp->getStatusCode()}" );
+				throw new WeblingAPIException( "Post request to Webling failed: {$resp->getRawData()}", $resp->getStatusCode() );
 			}
 			$id = $resp->getData();
 		}
@@ -482,7 +482,7 @@ class MemberRepository extends Repository {
 		}
 
 		if ( $resp->getStatusCode() !== 200 ) {
-			throw new WeblingAPIException( "Get request to Webling failed with status code {$resp->getStatusCode()}" );
+			throw new WeblingAPIException( "Get request to Webling failed: {$resp->getRawData()}", $resp->getStatusCode() );
 		}
 
 		$ids = $resp->getData()['objects'];
@@ -527,7 +527,7 @@ class MemberRepository extends Repository {
 		$data = $this->apiDelete( "member/$id" );
 
 		if ( $data->getStatusCode() !== 204 ) {
-			throw new WeblingAPIException( "Delete request to Webling failed with status code {$data->getStatusCode()}" );
+			throw new WeblingAPIException( "Delete request to Webling failed {$data->getRawData()}", $data->getStatusCode() );
 		}
 	}
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,7 +34,7 @@ Route::group( [ 'prefix' => 'v1', 'middleware' => [ 'api' ] ], function () {
 
 		Route::put( '{id}', function ( Request $request, $id ) {
 			$controller = new RestApiMember();
-			$id = $controller->updateMember( $request, $id );
+			$id         = $controller->updateMember( $request, $id );
 
 			return response( $id )
 				->header( 'Content-Type', 'application/json' )
@@ -43,7 +43,7 @@ Route::group( [ 'prefix' => 'v1', 'middleware' => [ 'api' ] ], function () {
 
 		Route::post( '', function ( Request $request ) {
 			$controller = new RestApiMember();
-			$id = $controller->upsertMember( $request );
+			$id         = $controller->upsertMember( $request );
 
 			return response( $id )
 				->header( 'Content-Type', 'application/json' )

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -44,7 +44,7 @@ class RestApiMemberTest extends TestCase {
 		$response = $this->json( 'GET', '/api/v1/member/1', [], $headers );
 
 		$response->assertStatus( 401 );
-		$this->assertRegExp( '/Get request to Webling failed with status code 401/', $response->getContent() );
+		$this->assertRegExp( '/Get request to Webling failed:.*Not authenticated/', $response->getContent() );
 	}
 
 	public function testGetMember_401() {

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -421,17 +421,17 @@ class RestApiMemberTest extends TestCase {
 
 	public function testPutMember_addIfNew_new_201() {
 		$m = [
-			'email1' => [
-				'value' => 'unittest_'.str_random().'@mail.com',
-				'mode' => 'replace',
+			'email1'       => [
+				'value' => 'unittest_' . str_random() . '@mail.com',
+				'mode'  => 'replace',
 			],
 			'entryChannel' => [
 				'value' => 'I am new here',
 				'mode'  => 'addIfNew'
 			],
-			'groups' => [
+			'groups'       => [
 				'value' => 100,
-				'mode' => 'append',
+				'mode'  => 'append',
 			]
 		];
 
@@ -457,7 +457,7 @@ class RestApiMemberTest extends TestCase {
 
 	public function testPutMember_replaceEmpty_notEmpty_201() {
 		$initial = 'already in the database';
-		$replace     = 'this should not be replaced';
+		$replace = 'this should not be replaced';
 
 		$member = $this->getMember();
 		$member->entryChannel->setValue( $initial );
@@ -492,7 +492,7 @@ class RestApiMemberTest extends TestCase {
 
 	public function testPutMember_replaceEmpty_empty_201() {
 		$initial = '';
-		$replace     = 'this should not be replaced';
+		$replace = 'this should not be replaced';
 
 		$member = $this->getMember();
 		$member->entryChannel->setValue( $initial );
@@ -525,13 +525,12 @@ class RestApiMemberTest extends TestCase {
 
 
 	public function testPutMember_append_500() {
-		$email = 'unittest_replace+' . str_random() . '@unittest.ut';
-
+		$date   = '2019-07-27';
 		$member = $this->addMember();
 
 		$m = [
-			'email1' => [
-				'value' => $email,
+			'birthday' => [
+				'value' => $date,
 				'mode'  => 'append'
 			]
 		];
@@ -817,6 +816,7 @@ class RestApiMemberTest extends TestCase {
 		$member->lastName->setValue( 'Test' );
 		$member->email1->setValue( 'unittest+' . str_random() . '@unittest.ut' );
 		$member->iban->setValue( '12345678' );
+		$member->birthday->setValue( '2000-01-01' );
 
 		$groupRepository = new GroupRepository( config( 'app.webling_api_key' ) );
 		$rootGroup       = $groupRepository->get( 100 );

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -385,6 +385,145 @@ class RestApiMemberTest extends TestCase {
 		$this->assertTrue( in_array( $appended, $m2->interests ) );
 	}
 
+	public function testPutMember_addIfNew_notNew_201() {
+		$initial = 'already in the database';
+		$add     = 'this should not be appended';
+
+		$member = $this->getMember();
+		$member->entryChannel->setValue( $initial );
+		$member = $this->saveMember( $member );
+
+		$m = [
+			'entryChannel' => [
+				'value' => $add,
+				'mode'  => 'addIfNew'
+			]
+		];
+
+		$put = $this->json(
+			'PUT',
+			'/api/v1/member/' . $member->id,
+			$m,
+			$this->auth->getAuthHeader()
+		);
+
+		$getUpdated = $this->json( 'GET', '/api/v1/admin/member/' . $member->id, [], $this->auth->getAuthHeader() );
+		$m2         = json_decode( $getUpdated->getContent() );
+
+		// call this before asserting anything so it gets also
+		// deleted if assertions fail.
+		$this->deleteMember( $member );
+
+		$this->assertEquals( 201, $put->getStatusCode() );
+		$this->assertTrue( 0 === strpos( $initial, $m2->entryChannel ) );
+		$this->assertTrue( false === strpos( $add, $m2->entryChannel ) );
+	}
+
+	public function testPutMember_addIfNew_new_201() {
+		$m = [
+			'email1' => [
+				'value' => 'unittest_'.str_random().'@mail.com',
+				'mode' => 'replace',
+			],
+			'entryChannel' => [
+				'value' => 'I am new here',
+				'mode'  => 'addIfNew'
+			],
+			'groups' => [
+				'value' => 100,
+				'mode' => 'append',
+			]
+		];
+
+		$put = $this->json(
+			'POST',
+			'/api/v1/member',
+			$m,
+			$this->auth->getAuthHeader()
+		);
+
+		$this->assertEquals( 201, $put->getStatusCode() );
+		$id = $put->getContent();
+
+		$getNew = $this->json( 'GET', '/api/v1/admin/member/' . $id, [], $this->auth->getAuthHeader() );
+		$m2     = json_decode( $getNew->getContent() );
+
+		// call this before asserting anything so it gets also
+		// deleted if assertions fail.
+		$this->deleteMember( $id );
+
+		$this->assertTrue( 0 === strpos( $m['entryChannel']['value'], $m2->entryChannel ) );
+	}
+
+	public function testPutMember_replaceEmpty_notEmpty_201() {
+		$initial = 'already in the database';
+		$replace     = 'this should not be replaced';
+
+		$member = $this->getMember();
+		$member->entryChannel->setValue( $initial );
+		$member = $this->saveMember( $member );
+
+		$m = [
+			'entryChannel' => [
+				'value' => $replace,
+				'mode'  => 'replaceEmpty'
+			]
+		];
+
+		$put = $this->json(
+			'PUT',
+			'/api/v1/member/' . $member->id,
+			$m,
+			$this->auth->getAuthHeader()
+		);
+
+		$getUpdated = $this->json( 'GET', '/api/v1/admin/member/' . $member->id, [], $this->auth->getAuthHeader() );
+		$m2         = json_decode( $getUpdated->getContent() );
+
+		// call this before asserting anything so it gets also
+		// deleted if assertions fail.
+		$this->deleteMember( $member );
+
+		$this->assertEquals( 201, $put->getStatusCode() );
+		$this->assertTrue( 0 === strpos( $initial, $m2->entryChannel ) );
+		$this->assertTrue( false === strpos( $replace, $m2->entryChannel ) );
+	}
+
+
+	public function testPutMember_replaceEmpty_empty_201() {
+		$initial = '';
+		$replace     = 'this should not be replaced';
+
+		$member = $this->getMember();
+		$member->entryChannel->setValue( $initial );
+		$member = $this->saveMember( $member );
+
+		$m = [
+			'entryChannel' => [
+				'value' => $replace,
+				'mode'  => 'replaceEmpty'
+			]
+		];
+
+		$put = $this->json(
+			'PUT',
+			'/api/v1/member/' . $member->id,
+			$m,
+			$this->auth->getAuthHeader()
+		);
+
+		$getUpdated = $this->json( 'GET', '/api/v1/admin/member/' . $member->id, [], $this->auth->getAuthHeader() );
+		$m2         = json_decode( $getUpdated->getContent() );
+
+		// call this before asserting anything so it gets also
+		// deleted if assertions fail.
+		$this->deleteMember( $member );
+
+		$this->assertEquals( 201, $put->getStatusCode() );
+		$this->assertEquals( $replace, $m2->entryChannel );
+	}
+
+
 	public function testPutMember_append_500() {
 		$email = 'unittest_replace+' . str_random() . '@unittest.ut';
 

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -43,7 +43,7 @@ class RestApiMemberTest extends TestCase {
 
 		$response = $this->json( 'GET', '/api/v1/member/1', [], $headers );
 
-		$response->assertStatus( 500 );
+		$response->assertStatus( 401 );
 		$this->assertRegExp( '/Get request to Webling failed with status code 401/', $response->getContent() );
 	}
 

--- a/tests/Unit/Repository/Member/Field/LongTextFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/LongTextFieldTest.php
@@ -1,18 +1,37 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
 
 namespace App\Repository\Member\Field;
 
 use Tests\TestCase;
 
 class LongTextFieldTest extends TestCase {
-	
+	private $key = 'internal';
+	private $weblingKey = 'webling key';
+	private $value = 'first value';
+	private $secondValue = 'second value';
+	private $separator = "\n";
+
 	public function test__constructValueLength() {
-		$key        = 'internal';
-		$weblingKey = 'webling key';
-		$value      = str_repeat( 'a', 500 );
-		
-		/** @noinspection PhpUnhandledExceptionInspection */
-		$field = new LongTextField( $key, $weblingKey, $value );
+		$field = $this->getField();
+		$value = str_repeat( 'a', 500 );
+		$field->setValue( $value );
+
 		$this->assertEquals( $value, $field->getValue() );
+	}
+
+	private function getField() {
+		return new LongTextField( $this->key, $this->weblingKey, $this->value );
+	}
+
+	public function testAppend__notInString() {
+		$field = $this->getField();
+		$field->append( $this->secondValue, true, $this->separator );
+		$this->assertEquals( $this->value . $this->separator . $this->secondValue, $field->getValue() );
+	}
+
+	public function testAppend__alreadyInString() {
+		$field = $this->getField();
+		$field->append( $this->value );
+		$this->assertEquals( $this->value, $field->getValue() );
 	}
 }

--- a/tests/Unit/Repository/Member/Field/LongTextFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/LongTextFieldTest.php
@@ -34,4 +34,12 @@ class LongTextFieldTest extends TestCase {
 		$field->append( $this->value );
 		$this->assertEquals( $this->value, $field->getValue() );
 	}
+
+	public function testAppend__emptyString() {
+		$field = $this->getField();
+		$field->setValue(null);
+
+		$field->append( $this->secondValue );
+		$this->assertEquals( $this->secondValue, $field->getValue() );
+	}
 }

--- a/tests/Unit/Repository/Member/Field/MultiSelectFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/MultiSelectFieldTest.php
@@ -105,6 +105,18 @@ class MultiSelectFieldTest extends TestCase {
 		/** @noinspection PhpUnhandledExceptionInspection */
 		$field->append( $this->possibleValues['no'] );
 		$this->assertEquals( array_keys( $this->possibleValues ), $field->getValue() );
+
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$field->append( null );
+		$this->assertEquals( array_keys( $this->possibleValues ), $field->getValue() );
+
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$field->append( array() );
+		$this->assertEquals( array_keys( $this->possibleValues ), $field->getValue() );
+
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$field->append( '' );
+		$this->assertEquals( array_keys( $this->possibleValues ), $field->getValue() );
 	}
 	
 	public function testRemove() {

--- a/tests/Unit/Repository/Member/Field/TextFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/TextFieldTest.php
@@ -49,4 +49,11 @@ class TextFieldTest extends TestCase {
 		$this->assertEquals( $this->value, $field->getValue() );
 	}
 
+	public function testAppend__emptyString() {
+		$field = $this->getField();
+		$field->setValue(null);
+
+		$field->append( $this->secondValue );
+		$this->assertEquals( $this->secondValue, $field->getValue() );
+	}
 }

--- a/tests/Unit/Repository/Member/Field/TextFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/TextFieldTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
 /**
  * Created by PhpStorm.
  * User: cyrillbolliger
@@ -15,25 +16,37 @@ class TextFieldTest extends TestCase {
 	private $key = 'internal';
 	private $weblingKey = 'webling key';
 	private $value = 'short enough';
-	
+	private $secondValue = 'second value';
+	private $separator = ', ';
+
 	public function testSetValueInputLengthException() {
 		$twoHundredFiftySixChars = str_repeat( 'a', 256 );
 		$this->expectException( InputLengthException::class );
 		$field = $this->getField();
-		/** @noinspection PhpUnhandledExceptionInspection */
 		$field->setValue( $twoHundredFiftySixChars );
 	}
-	
+
 	private function getField() {
-		/** @noinspection PhpUnhandledExceptionInspection */
 		return new TextField( $this->key, $this->weblingKey, $this->value );
 	}
-	
+
 	public function testSetValueInputLength() {
 		$twoHundredFiftyFiveChars = str_repeat( 'a', 255 );
 		$field                    = $this->getField();
-		/** @noinspection PhpUnhandledExceptionInspection */
 		$field->setValue( $twoHundredFiftyFiveChars );
 		$this->assertEquals( $twoHundredFiftyFiveChars, $field->getValue() );
 	}
+
+	public function testAppend__notInString() {
+		$field = $this->getField();
+		$field->append( $this->secondValue, true, $this->separator );
+		$this->assertEquals( $this->value . $this->separator . $this->secondValue, $field->getValue() );
+	}
+
+	public function testAppend__alreadyInString() {
+		$field = $this->getField();
+		$field->append( $this->value );
+		$this->assertEquals( $this->value, $field->getValue() );
+	}
+
 }


### PR DESCRIPTION
* Neu gibt es die Möglichkeit, Werte nur zu schreiben, wenn entweder der Datensatz neu ist oder wenn das Feld noch leer ist. Dies ist nützlich um Formulareingaben von der Website einzuspeisen.
* Zwei Fehlermeldungen, die ich nach Anpassung der POST/PUT Datenstruktur für Updates, vergessen habe, anzupassen, habe ich auch noch gleich korrigiert.