### PR TITLE
Restricted access

### DIFF
--- a/app/Console/Commands/DeleteClient.php
+++ b/app/Console/Commands/DeleteClient.php
@@ -50,6 +50,7 @@ class DeleteClient extends ClientCommand
             }
             
             \App\ClientGroup::where('client_id', $id)->delete();
+            \App\WeblingKey::where('client_id', $id)->delete();
             DB::table('oauth_access_tokens')->where('client_id', '=', $id)->delete();
             DB::table('oauth_clients')->where('id', '=', $id)->delete();
             

--- a/app/Console/Commands/EditClient.php
+++ b/app/Console/Commands/EditClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
 
 class EditClient extends ClientCommand
@@ -14,6 +15,7 @@ class EditClient extends ClientCommand
     protected $signature = 'client:edit 
                             {id : Client ID}
                             {--name= : Client name (human readable identifier)}
+                            {--webling-key : Webling API key}
                             {--g|root-group=* : The root group (id) the client should have access to. Repeat the option for multiple groups.}';
     
     /**
@@ -42,6 +44,7 @@ class EditClient extends ClientCommand
     {
         $id = (int)$this->argument('id');
         $name = $this->option('name');
+        $key = $this->option('webling-key');
         $groups = $this->option('root-group');
         
         $client = $this->getClientById($id);
@@ -54,6 +57,14 @@ class EditClient extends ClientCommand
             DB::table('oauth_clients')->where('id', $id)->update(['name' => $name]);
             
             $this->info('Successfully changed name.');
+        }
+        
+        if (!empty($key)) {
+            $keyModel = \App\WeblingKey::where('client_id', $id)->first();
+            $keyModel->api_key = Crypt::encryptString($key);
+            $keyModel->save();
+            
+            $this->info('Successfully changed Webling API key.');
         }
         
         if (!empty($groups)) {

--- a/app/Console/Commands/EditClient.php
+++ b/app/Console/Commands/EditClient.php
@@ -15,7 +15,7 @@ class EditClient extends ClientCommand
     protected $signature = 'client:edit 
                             {id : Client ID}
                             {--name= : Client name (human readable identifier)}
-                            {--webling-key : Webling API key}
+                            {--webling-key= : Webling API key}
                             {--g|root-group=* : The root group (id) the client should have access to. Repeat the option for multiple groups.}';
     
     /**

--- a/app/Console/Commands/EditClient.php
+++ b/app/Console/Commands/EditClient.php
@@ -70,8 +70,8 @@ class EditClient extends ClientCommand
             
             $keyModel->api_key = Crypt::encryptString($key);
             $keyModel->save();
-            
-            $this->info('Successfully changed Webling API key.');
+    
+            $this->info('<comment>Changed Webling key to:</comment> ' . $key . ' (stored encrypted)');
         }
         
         if (!empty($groups)) {

--- a/app/Console/Commands/EditClient.php
+++ b/app/Console/Commands/EditClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\WeblingKey;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
 
@@ -61,6 +62,12 @@ class EditClient extends ClientCommand
         
         if (!empty($key)) {
             $keyModel = \App\WeblingKey::where('client_id', $id)->first();
+            
+            if (!$keyModel) {
+                $keyModel = new WeblingKey();
+                $keyModel->client_id = $id;
+            }
+            
             $keyModel->api_key = Crypt::encryptString($key);
             $keyModel->save();
             

--- a/app/Console/Commands/ListClient.php
+++ b/app/Console/Commands/ListClient.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
 
 class ListClient extends Command
@@ -43,16 +44,19 @@ class ListClient extends Command
         $data = [];
         foreach ($clients as $client) {
             $groups = \App\ClientGroup::where('client_id', $client->id)->pluck('root_group')->toArray();
+            $keyModel = \App\WeblingKey::where('client_id', $client->id)->first();
             
             $data[] = [
                 $client->id,
                 $client->name,
                 implode(' ', $groups),
-                $client->created_at
+                $keyModel ? Crypt::decryptString($keyModel->api_key) : '',
+                $client->updated_at,
+                $client->created_at,
             ];
         }
-        
-        $headers = ['ID', 'Name', 'Root Groups', 'Created'];
+    
+        $headers = ['ID', 'Name', 'Root Groups', 'Webling Key', 'Updated', 'Created'];
         
         $this->table($headers, $data);
         

--- a/app/Http/Controllers/RestApi/ApiHelper.php
+++ b/app/Http/Controllers/RestApi/ApiHelper.php
@@ -141,8 +141,8 @@ class ApiHelper
         if (empty($allowedGroups)) {
             abort(403, 'Not authorized.');
         }
-        
-        $groupRepository = self::createGroupRepo($request->header($key = 'db_key'));
+    
+        $groupRepository = self::createGroupRepo();
         
         $groups = [];
         foreach ($allowedGroups as $groupId) {

--- a/app/Http/Controllers/RestApi/RestApiMember.php
+++ b/app/Http/Controllers/RestApi/RestApiMember.php
@@ -126,7 +126,7 @@ class RestApiMember
             $requestedGroups = [];
             
             /** @var GroupRepository $groupRepository */
-            $groupRepository = ApiHelper::createGroupRepo($request->header($key = 'db_key'));
+            $groupRepository = ApiHelper::createGroupRepo();
             
             foreach ($group_ids as $groupId) {
                 ApiHelper::checkIntegerInput($groupId);
@@ -381,7 +381,7 @@ class RestApiMember
     private function patchGroups(Request &$request, Member &$member, array $data)
     {
         $groups = [];
-        $groupRepo = ApiHelper::createGroupRepo($request->header($key = 'db_key'));
+        $groupRepo = ApiHelper::createGroupRepo();
         $allowedGroups = ApiHelper::getAllowedGroups($request);
     
         foreach ((array) $data['value'] as $group) {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends HttpKernel
             'bindings',
             'client',
             \App\Http\Middleware\AddAllowedRootGroups::class,
+            \App\Http\Middleware\InjectWeblingKey::class,
         ],
     ];
     

--- a/app/Http/Middleware/AddAllowedRootGroups.php
+++ b/app/Http/Middleware/AddAllowedRootGroups.php
@@ -14,7 +14,6 @@ use Lcobucci\JWT\Parser;
 class AddAllowedRootGroups
 {
     protected $clientRepository = null;
-    protected $tokenRepository = null;
     
     public function __construct(ClientRepository $clientRepository)
     {

--- a/app/Http/Middleware/InjectWeblingKey.php
+++ b/app/Http/Middleware/InjectWeblingKey.php
@@ -28,8 +28,8 @@ class InjectWeblingKey
         
         $keyModel = WeblingKey::where('client_id', $clientId)->first();
         $key = Crypt::decryptString($keyModel->api_key);
-        
-        $request->merge(['db_key' => $key]);
+    
+        $request->headers->set('db_key', $key, false);
         
         return $next($request);
     }

--- a/app/Http/Middleware/InjectWeblingKey.php
+++ b/app/Http/Middleware/InjectWeblingKey.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\WeblingKey;
+use Closure;
+use Illuminate\Support\Facades\Crypt;
+use Lcobucci\JWT\Parser;
+
+class InjectWeblingKey
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        /**
+         * get client from token
+         *
+         * @see https://github.com/laravel/passport/issues/143
+         */
+        $jwt = (new Parser())->parse($request->bearerToken());
+        $clientId = $jwt->getClaim('aud');
+        
+        $keyModel = WeblingKey::where('client_id', $clientId)->first();
+        $key = Crypt::decryptString($keyModel->api_key);
+        
+        $request->merge(['db_key' => $key]);
+        
+        return $next($request);
+    }
+}

--- a/app/Repository/Repository.php
+++ b/app/Repository/Repository.php
@@ -15,7 +15,9 @@ use Webling\API\ClientException;
 abstract class Repository
 {
     /**
-     * Timout for requests to webling. Yes, it must be super high, we had issues with lower limits.
+     * Timeout for requests to webling in seconds.
+     *
+     * Yes, it must be super high, we had issues with lower limits.
      */
     private const TIMEOUT = 60;
     private const CONNECTTIMEOUT = 4;

--- a/app/Repository/Repository.php
+++ b/app/Repository/Repository.php
@@ -14,9 +14,10 @@ use Webling\API\Client;
 abstract class Repository
 {
     /**
-     * Timout for requests to webling. Yes, it must be super high, webling is sometimes super slow!
+     * Timout for requests to webling. Yes, it must be super high, we had issues with lower limits.
      */
     private const TIMEOUT = 60;
+    private const CONNECTTIMEOUT = 30;
     
     /**
      * The api key
@@ -62,7 +63,12 @@ abstract class Repository
         $this->api_key = $api_key;
         $this->api_url = $api_url;
     
-        $this->webling_client = new Client($api_url, $api_key, ['timeout' => self::TIMEOUT]);
+        $curlOptions = [
+            'timeout' => self::TIMEOUT,
+            'connecttimeout' => self::CONNECTTIMEOUT
+        ];
+    
+        $this->webling_client = new Client($api_url, $api_key, $curlOptions);
     }
     
     /**

--- a/app/Repository/Repository.php
+++ b/app/Repository/Repository.php
@@ -14,6 +14,11 @@ use Webling\API\Client;
 abstract class Repository
 {
     /**
+     * Timout for requests to webling. Yes, it must be super high, webling is sometimes super slow!
+     */
+    private const TIMEOUT = 60;
+    
+    /**
      * The api key
      *
      * Exposed to child classes, so they can instantiate further repositories.
@@ -56,8 +61,8 @@ abstract class Repository
         
         $this->api_key = $api_key;
         $this->api_url = $api_url;
-        
-        $this->webling_client = new Client($api_url, $api_key);
+    
+        $this->webling_client = new Client($api_url, $api_key, ['timeout' => self::TIMEOUT]);
     }
     
     /**

--- a/app/WeblingKey.php
+++ b/app/WeblingKey.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WeblingKey extends Model
+{
+    //
+}

--- a/config/member-json-fields.yml
+++ b/config/member-json-fields.yml
@@ -8,13 +8,22 @@ mappings:
   - language
   - newsletterCountryD
   - newsletterCountryF
+  - newsletterCantonD
+  - newsletterCantonF
   - newsletterMunicipality
   - newsletterOther
   - pressReleaseCountryD
   - pressReleaseCountryF
+  - pressReleaseCantonD
+  - pressReleaseCantonF
   - memberStatusCountry
+  - memberStatusCanton
+  - memberStatusMunicipality
+  - membershipStart
   - interests
   - donorCountry
+  - donorCanton
+  - donorMunicipality
   - notesCountry
   - recordCategory
   - recordStatus

--- a/database/migrations/2019_11_13_101737_create_webling_keys_table.php
+++ b/database/migrations/2019_11_13_101737_create_webling_keys_table.php
@@ -30,6 +30,6 @@ class CreateWeblingKeysTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('WeblingKeys');
+        Schema::dropIfExists('webling_keys');
     }
 }

--- a/database/migrations/2019_11_13_101737_create_webling_keys_table.php
+++ b/database/migrations/2019_11_13_101737_create_webling_keys_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateWeblingKeysTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('webling_keys', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('client_id');
+            $table->string('api_key', 255);
+            $table->timestamps();
+            
+            $table->foreign('client_id')->references('id')->on('oauth_clients');
+        });
+    }
+    
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('WeblingKeys');
+    }
+}

--- a/tests/Feature/Http/Controllers/RestApi/AuthHelper.php
+++ b/tests/Feature/Http/Controllers/RestApi/AuthHelper.php
@@ -54,6 +54,7 @@ class AuthHelper
     {
         Artisan::call('client:add', [
             'name' => 'Unit Test',
+            'webling-key' => config('app.webling_api_key'),
             '--root-group' => $rootGroups
         ]);
         

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -930,6 +930,30 @@ class RestApiMemberTest extends TestCase
         $response->assertJsonCount(1, 'matches');
     }
     
+    public function testPostMatch_200_match_ampersand()
+    {
+        $member = $this->getMember();
+        $member->firstName->setValue("P. & M.");
+        $member = $this->saveMember($member);
+        
+        $m = [
+            'firstName' => [
+                'value' => $member->firstName->getValue(),
+            ],
+            'lastName' => [
+                'value' => $member->lastName->getValue(),
+            ]
+        ];
+        
+        $response = $this->json('POST', '/api/v1/member/match', $m, $this->auth->getAuthHeader());
+        
+        $this->deleteMember($member);
+        
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['status', 'matches']);
+        $response->assertJsonCount(1, 'matches');
+    }
+    
     public function testPostMatch_200_ambiguous()
     {
         $member = $this->getMember();

--- a/tests/Unit/Console/Commands/AddClientTest.php
+++ b/tests/Unit/Console/Commands/AddClientTest.php
@@ -10,6 +10,7 @@ namespace App\Console\Commands;
 
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Crypt;
 use Tests\TestCase;
 
 class AddClientTest extends TestCase
@@ -17,8 +18,11 @@ class AddClientTest extends TestCase
     
     public function testHandle_successful()
     {
+        $key = 'secret';
+        
         $exitCode = Artisan::call('client:add', [
             'name' => 'Unit Test',
+            'webling-key' => $key,
             '--root-group' => [10]
         ]);
         
@@ -26,21 +30,29 @@ class AddClientTest extends TestCase
         
         preg_match("/Client ID: (\d+)/", $output, $clientId);
         preg_match("/Root groups: (\d+)/", $output, $rootGroups);
+    
+        $clientId = (int)$clientId[1];
+        $rootGroups = $rootGroups[1];
+    
+        $keyModel = \App\WeblingKey::where('client_id', $clientId)->first();
         
         // clean up before asserting
-        Artisan::call('client:delete', ['id' => [(int)$clientId[1]]]);
+        Artisan::call('client:delete', ['id' => [$clientId]]);
         
         $this->assertEquals(0, $exitCode);
         $this->assertTrue(1 === preg_match("/Client secret: \w+/", $output));
+        $this->assertTrue(1 === preg_match("/Webling Key: \w+/", $output));
         $this->assertTrue(1 === preg_match("/New client created successfully./", $output));
-        $this->assertEquals('10', $rootGroups[1]);
-        $this->assertNotEmpty($clientId[1]);
+        $this->assertEquals('10', $rootGroups);
+        $this->assertNotEmpty($clientId);
+        $this->assertEquals($key, Crypt::decryptString($keyModel->api_key));
     }
     
     public function testHandle_successfulMultipleGroupsShorthand()
     {
         $exitCode = Artisan::call('client:add', [
             'name' => 'Unit Test',
+            'webling-key' => 'secret',
             '-g' => [10, 20]
         ]);
         
@@ -69,10 +81,21 @@ class AddClientTest extends TestCase
         ]);
     }
     
+    public function testHandle_missingKey()
+    {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        
+        $this->artisan('client:add', [
+            'name' => 'Unit Test',
+            '--root-group' => [10]
+        ]);
+    }
+    
     public function testHandle_noGroup()
     {
         $this->artisan('client:add', [
-            'name' => 'asdf'
+            'name' => 'asdf',
+            'webling-key' => 'secret',
         ])->assertExitCode(1);
     }
     
@@ -80,6 +103,7 @@ class AddClientTest extends TestCase
     {
         $this->artisan('client:add', [
             'name' => 'asdf',
+            'webling-key' => 'secret',
             '-g' => ['asdf']
         ])->assertExitCode(1);
     }

--- a/tests/Unit/Console/Commands/DeleteClientTest.php
+++ b/tests/Unit/Console/Commands/DeleteClientTest.php
@@ -31,6 +31,7 @@ class DeleteClientTest extends TestCase
     {
         Artisan::call('client:add', [
             'name' => 'Unit Test',
+            'webling-key' => 'secret',
             '--root-group' => [10]
         ]);
         

--- a/tests/Unit/Console/Commands/EditClientTest.php
+++ b/tests/Unit/Console/Commands/EditClientTest.php
@@ -77,7 +77,7 @@ class EditClientTest extends TestCase
         $this->artisan('client:edit', [
             'id' => $this->clientId,
             '--webling-key' => $key
-        ])->expectsOutput('Successfully changed Webling API key.')
+        ])->expectsOutput('Changed Webling key to: ' . $key)
             ->assertExitCode(0);
         
         $keyModel = \App\WeblingKey::where('client_id', $this->clientId)->first();

--- a/tests/Unit/Console/Commands/EditClientTest.php
+++ b/tests/Unit/Console/Commands/EditClientTest.php
@@ -77,7 +77,7 @@ class EditClientTest extends TestCase
         $this->artisan('client:edit', [
             'id' => $this->clientId,
             '--webling-key' => $key
-        ])->expectsOutput('Changed Webling key to: ' . $key)
+        ])->expectsOutput("Changed Webling key to: $key (stored encrypted)")
             ->assertExitCode(0);
         
         $keyModel = \App\WeblingKey::where('client_id', $this->clientId)->first();

--- a/tests/Unit/Console/Commands/EditClientTest.php
+++ b/tests/Unit/Console/Commands/EditClientTest.php
@@ -10,6 +10,7 @@ namespace App\Console\Commands;
 
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Crypt;
 use Tests\TestCase;
 
 class EditClientTest extends TestCase
@@ -22,6 +23,7 @@ class EditClientTest extends TestCase
         
         Artisan::call('client:add', [
             'name' => 'Unit Test',
+            'webling-key' => 'secret',
             '--root-group' => [10]
         ]);
         
@@ -66,5 +68,20 @@ class EditClientTest extends TestCase
         ])->expectsOutput('Deleted groups: 10')
             ->expectsOutput('Added groups: 20')
             ->assertExitCode(0);
+    }
+    
+    public function testHandle_successfulWeblingKey()
+    {
+        $key = 'new-secret';
+        
+        $this->artisan('client:edit', [
+            'id' => $this->clientId,
+            '--webling-key' => $key
+        ])->expectsOutput('Successfully changed Webling API key.')
+            ->assertExitCode(0);
+        
+        $keyModel = \App\WeblingKey::where('client_id', $this->clientId)->first();
+        
+        $this->assertEquals($key, Crypt::decryptString($keyModel->api_key));
     }
 }

--- a/tests/Unit/Console/Commands/ListClientTest.php
+++ b/tests/Unit/Console/Commands/ListClientTest.php
@@ -15,6 +15,7 @@ use Tests\TestCase;
 class ListClientTest extends TestCase
 {
     private $clientId;
+    private $key = 'super_secret';
     
     public function setUp(): void
     {
@@ -22,6 +23,7 @@ class ListClientTest extends TestCase
         
         Artisan::call('client:add', [
             'name' => 'Unit Test',
+            'webling-key' => $this->key,
             '--root-group' => [10]
         ]);
         
@@ -46,7 +48,7 @@ class ListClientTest extends TestCase
         $output = Artisan::output();
         
         $this->assertEquals(0, $exitCode);
-        $this->assertRegExp('/^| ID\s+| Name\s+| Root Groups\s+| Created\s+|/', $output);
-        $this->assertRegExp('/| ' . $this->clientId . '\s+| Unit Test\s+| 10\s+ | \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} |/', $output);
+        $this->assertRegExp('/^| ID\s+| Name\s+| Root Groups\s+| Webling Key\s+| Updated\s+| Created\s+|/', $output);
+        $this->assertRegExp('/| ' . $this->clientId . '\s+| Unit Test\s+| 10\s+| ' . $this->key . '\s+ | \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} | \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} |/', $output);
     }
 }


### PR DESCRIPTION
Der Weblingservice kommt erstmalig auch für Kantonalparteien zum Einsatz. Ursprüglich haben wir ja gedacht, dass sämtliche Clients ihre eigenen Webling API-Keys vom Endsystem über den Weblingservice bis zu Webling durchreichen. Nun schien mir das Key-Management aber wesentlich einfacher, wenn dieses zentral ist und wir nur die oAuth-Tokens verteilen müssen. Daher habe ich den Weblingservice kurzerhand umgebaut.

Neu werden die API Keys für Webling vom Webling-Service gespeichert, pro Client. Eine Middleware injected nach der Authentisierung den entsprechenden Key in den Header. Danach läuft es weiter wie urspruünglich angedacht.

Weiter habe ich noch gemerkt, dass wir ein Problem mit den gechachten Gruppen erhalten, wenn diese mit Keys von unterschiedlicher Berechtigung abgerufen werden (weil dann zB der Root Path unvollständig ist). Darum habe ich für die Gruppen überall den default Key eingesetzt.

Und weil wir immer wieder Timeoutprobleme haben, habe ich das Curltimeout noch von 30 (Webling default) auf 60 Sekunden erhöht. Zudem habe ich für die GET und PUT requests einen Mechanismus eingebaut um fehlgeschlagene Requests bis zu zwei mal zu wiederholen.