### PR TITLE
expose address

### DIFF
--- a/config/member-json-fields.yml
+++ b/config/member-json-fields.yml
@@ -6,6 +6,8 @@ mappings:
   - recordCategory
   - emailStatus
   - language
+  - address1
+  - zip
   - city
   - newsletterCountryD
   - newsletterCountryF


### PR DESCRIPTION
Für Automatisierungen bezüglich Onlinespenden brauchen wir die Adresse. Datensparsamkeit wird weiterhin eingehalten, da sie der Mailchimpservice nicht zu Mailchimp synchronisiert.

PS: Der automatisierte Test wird fehlschlagen, da wir auf dem Testwebling eine neue Konfiguration am Testen sind.