### PR TITLE
Feature: field update mode 'remove' and multiple field actions

### DIFF
--- a/app/Http/Controllers/RestApi/RestApiMember.php
+++ b/app/Http/Controllers/RestApi/RestApiMember.php
@@ -20,6 +20,7 @@ class RestApiMember
     private const MODE_REPLACE_EMPTY = 'replaceEmpty';
     private const MODE_APPEND = 'append';
     private const MODE_ADD_IF_NEW = 'addIfNew';
+    private const MODE_REMOVE = 'remove';
     
     /**
      * Return a json with the member fields
@@ -365,7 +366,7 @@ class RestApiMember
      *
      * @param  Request  $request
      * @param  Member  $member
-     * @param  array  $data  => [ value => [ group ids ], mode => replace/append ]
+     * @param  array  $data  => [ value => [ group ids ], mode => replace/append/remove ]
      *
      * @throws \App\Exceptions\GroupNotFoundException
      * @throws \App\Exceptions\InvalidFixedValueException
@@ -410,6 +411,10 @@ class RestApiMember
                     $member->setGroups($groups);
                 }
                 break;
+                
+            case self::MODE_REMOVE:
+                $member->removeGroups($groups);
+                break;
             
             default:
                 throw new IllegalFieldUpdateMode("The update mode '{$data['mode']}' for the field '".Member::KEY_GROUPS."' is not supported.");
@@ -451,6 +456,13 @@ class RestApiMember
                 if (null === $member->id) {
                     $member->$key->setValue($data['value']);
                 }
+                break;
+    
+            case self::MODE_REMOVE:
+                if (!method_exists($member->$key, 'remove')) {
+                    throw new IllegalFieldUpdateMode("The update mode '{$data['mode']}' for the field '$key' is not supported.");
+                }
+                $member->$key->remove($data['value']);
                 break;
             
             default:

--- a/app/Repository/Member/Field/LongTextField.php
+++ b/app/Repository/Member/Field/LongTextField.php
@@ -8,6 +8,9 @@
 
 namespace App\Repository\Member\Field;
 
+use App\Exceptions\InputLengthException;
+use App\Exceptions\ValueTypeException;
+
 class LongTextField extends FreeField
 {
     /**
@@ -30,6 +33,33 @@ class LongTextField extends FreeField
         } else {
             $v = $this->getValue() . $separator . $value;
         }
+        
+        $this->setValue($v, $dirty);
+    }
+    
+    /**
+     * Remove value, if it's in the the field.
+     *
+     * @param $value
+     * @param bool $dirty
+     * @param string $separator
+     *
+     * @throws InputLengthException
+     * @throws ValueTypeException
+     */
+    public function remove($value, bool $dirty = true, string $separator = "\n" )
+    {
+        if (empty($value)
+            || empty($this->getValue())
+            || !$this->inValue($value)) {
+            return;
+        }
+        
+        $needle = preg_quote($value, '/');
+        $v = preg_replace("/\b$needle\b/", '', $this->getValue());
+        
+        $preg_separator = preg_quote($separator, '/');
+        $v = preg_replace("/\s*$preg_separator+\s*/", $separator, $v);
         
         $this->setValue($v, $dirty);
     }

--- a/app/Repository/Member/Field/Mapping/Loader.php
+++ b/app/Repository/Member/Field/Mapping/Loader.php
@@ -26,7 +26,8 @@ class Loader
     const RESERVED = [
         'groups',
         'id',
-        'firstLevelGroupNames'
+        'firstLevelGroupNames',
+        'value'
     ];
     
     /**

--- a/app/Repository/Member/Field/TextField.php
+++ b/app/Repository/Member/Field/TextField.php
@@ -37,6 +37,33 @@ class TextField extends FreeField
     }
     
     /**
+     * Remove value, if it's in the the field.
+     *
+     * @param $value
+     * @param bool $dirty
+     * @param string $separator
+     *
+     * @throws InputLengthException
+     * @throws ValueTypeException
+     */
+    public function remove($value, bool $dirty = true, string $separator = ', ')
+    {
+        if (empty($value)
+            || empty($this->getValue())
+            || !$this->inValue($value)) {
+            return;
+        }
+        
+        $needle = preg_quote($value, '/');
+        $v = preg_replace("/\b$needle\b/", '', $this->getValue());
+    
+        $preg_separator = preg_quote(trim($separator), '/');
+        $v = preg_replace("/(\s*$preg_separator+\s*)+/", $separator, $v);
+        
+        $this->setValue($v, $dirty);
+    }
+    
+    /**
      * Make sure we don't exceed the length limit
      *
      * @param string|null $value

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,6 +41,7 @@ The `id` property is read only.
 Field update modes:
 * `replace` replaces the current value
 * `append` appends the given value to the current value. Doesn't work for fields of type `DateField` and `SelectField`
+* `remove` removes the given value from the current value. Doesn't work for fields of type `DateField` and `SelectField`
 * `replaceEmpty` adds the given value only if the field is empty
 * `addIfNew` adds the given value only if this is a new record
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,6 +45,40 @@ Field update modes:
 * `replaceEmpty` adds the given value only if the field is empty
 * `addIfNew` adds the given value only if this is a new record
 
+On any field, a single action or multiple actions may be performed.
+* Single action example
+    ```json
+    {
+        "interests": 
+        {
+            "value": "energy", 
+            "mode": "append"
+        }
+    }
+    ```
+  This will add the `energy` interest flag without changing any other flags.
+
+  
+* Multi action example: 
+  ```json
+  {
+      "interests":
+      [
+          {
+              "value": "climate", 
+              "mode": "append"
+          },
+          {
+              "value": "agriculture", 
+              "mode": "remove"
+          }
+      ]
+  }
+  ``` 
+  This will add the `climate` interest flag and remove the `agriculture` flag
+  but wont affect any other flags. 
+
+
 ### Show single
 #### Regular request
 Request:
@@ -222,10 +256,16 @@ Body:
         "mode": "addIfNew"
     },
     "notesCountry": 
-    {
-        "value": "SomeTag",
-        "mode": "append"
-    },
+    [
+        {
+          "value": "aNewTag", 
+          "mode": "append"
+        },
+        {
+          "value": "anOldTag", 
+          "mode": "remove"
+        }
+    ],
     "groups":
     {
         "value": [201, 202],
@@ -271,10 +311,16 @@ Body:
         "mode": "addIfNew"
     },
     "notesCountry": 
-    {
-        "value": "SomeTag",
-        "mode": "append"
-    },
+    [
+        {
+          "value": "aNewTag", 
+          "mode": "append"
+        },
+        {
+          "value": "anOldTag", 
+          "mode": "remove"
+        }
+    ],
     "groups":
     {
         "value": [201, 202],

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -547,6 +547,48 @@ class RestApiMemberTest extends TestCase
         self::assertEquals($initial, $m2->notesCountry);
     }
     
+    public function testPutMember_removeAndAppendText_201(): void
+    {
+        $remove = 'tagtagtag';
+        $append = 'anewtag';
+        $initial = "this is a note\nanothertag\n$remove";
+        $final = "this is a note\nanothertag\n$append";
+        
+        $member = $this->getMember();
+        $member->notesCountry->append($initial);
+        $member = $this->saveMember($member);
+        
+        $m = [
+            'notesCountry' => [
+                [
+                    'value' => $remove,
+                    'mode' => 'remove'
+                ],
+                [
+                    'value' => $append,
+                    'mode' => 'append'
+                ]
+            ]
+        ];
+        
+        $put = $this->json(
+            'PUT',
+            '/api/v1/member/' . $member->id,
+            $m,
+            $this->auth->getAuthHeader()
+        );
+        
+        $getUpdated = $this->json('GET', '/api/v1/admin/member/' . $member->id, [], $this->auth->getAuthHeader());
+        $m2 = json_decode($getUpdated->getContent(), false, 512, JSON_THROW_ON_ERROR);
+        
+        // call this before asserting anything so it gets also
+        // deleted if assertions fail.
+        $this->deleteMember($member);
+        
+        self::assertEquals(201, $put->getStatusCode());
+        self::assertEquals($final, $m2->notesCountry);
+    }
+    
     public function testPutMember_addIfNew_notNew_201()
     {
         $initial = 'already in the database';

--- a/tests/Unit/Repository/Member/Field/LongTextFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/LongTextFieldTest.php
@@ -48,4 +48,68 @@ class LongTextFieldTest extends TestCase
         $field->append($this->secondValue);
         $this->assertEquals($this->secondValue, $field->getValue());
     }
+    
+    public function testRemove__notPresent()
+    {
+        $field = $this->getField();
+        $field->remove($this->secondValue, true, $this->separator);
+        self::assertEquals($this->value, $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__present()
+    {
+        $field = $this->getField();
+        $field->remove($this->value);
+        self::assertEmpty($field->getValue());
+        self::assertTrue($field->isDirty());
+        
+    }
+    
+    public function testRemove__empty()
+    {
+        $field = $this->getField();
+        $field->setValue(null, false);
+        
+        $field->remove($this->value);
+        self::assertNull($field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__nothing()
+    {
+        $field = $this->getField();
+        
+        $field->remove('');
+        self::assertEquals($this->value, $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__cut()
+    {
+        $field = $this->getField();
+        $field->setValue("some text\ntagtagtag \n tagtagtag asdf other");
+        $field->remove('tagtagtag');
+        self::assertEquals("some text\nasdf other", $field->getValue());
+        self::assertTrue($field->isDirty());
+        
+    }
+    
+    public function testRemove__noWordFractions1()
+    {
+        $field = $this->getField();
+        $field->setValue("some text\nKtagtagtag", false);
+        $field->remove('tagtagtag');
+        self::assertEquals("some text\nKtagtagtag", $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__noWordFractions2()
+    {
+        $field = $this->getField();
+        $field->setValue("some text\ntagtagtagK", false);
+        $field->remove('tagtagtag');
+        self::assertEquals("some text\ntagtagtagK", $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
 }

--- a/tests/Unit/Repository/Member/Field/TextFieldTest.php
+++ b/tests/Unit/Repository/Member/Field/TextFieldTest.php
@@ -63,4 +63,69 @@ class TextFieldTest extends TestCase
         $field->append($this->secondValue);
         $this->assertEquals($this->secondValue, $field->getValue());
     }
+    
+    
+    public function testRemove__notPresent()
+    {
+        $field = $this->getField();
+        $field->remove($this->secondValue, true, $this->separator);
+        self::assertEquals($this->value, $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__present()
+    {
+        $field = $this->getField();
+        $field->remove($this->value);
+        self::assertEmpty($field->getValue());
+        self::assertTrue($field->isDirty());
+        
+    }
+    
+    public function testRemove__empty()
+    {
+        $field = $this->getField();
+        $field->setValue(null, false);
+        
+        $field->remove($this->value);
+        self::assertNull($field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__nothing()
+    {
+        $field = $this->getField();
+        
+        $field->remove('');
+        self::assertEquals($this->value, $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__cut()
+    {
+        $field = $this->getField();
+        $field->setValue("some text, tagtagtag , tagtagtag ,, tagtagtag,other,tagtagtag asdf other");
+        $field->remove('tagtagtag');
+        self::assertEquals("some text, other, asdf other", $field->getValue());
+        self::assertTrue($field->isDirty());
+        
+    }
+    
+    public function testRemove__noWordFractions1()
+    {
+        $field = $this->getField();
+        $field->setValue("some text, Ktagtagtag", false);
+        $field->remove('tagtagtag');
+        self::assertEquals("some text, Ktagtagtag", $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
+    
+    public function testRemove__noWordFractions2()
+    {
+        $field = $this->getField();
+        $field->setValue("some text, tagtagtagK", false);
+        $field->remove('tagtagtag');
+        self::assertEquals("some text, tagtagtagK", $field->getValue());
+        self::assertFalse($field->isDirty());
+    }
 }


### PR DESCRIPTION
Adds the possibility to remove values from fields.
* On multi select fields, the value is unchecked
* On text fields, the given string is removed, if it has word boundaries on both ends (regex: `\b`)
* Date and single select fields do not support this mode
* For groups, the member is removed from the given group

Provides option to process multiple actions per field.
* Fields do now also accept an array of actions and process all of them.