### PR TITLE
Fix missing group names (affects MailChimp Sync)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Show logs if tests failed
         if: ${{ failure() }}
-        run: cat storage/logs/laravel-*.log
+        run: cat storage/logs/laravel*.log
 
       - name: publish coverage report
         if: ${{ success() }}

--- a/app/Http/Controllers/RestApi/ApiHelper.php
+++ b/app/Http/Controllers/RestApi/ApiHelper.php
@@ -53,7 +53,7 @@ class ApiHelper
         foreach ($allowedGroups as $group) {
             $rootGroupIds = $member->getFirstLevelGroupIds($group->getId());
             foreach ($rootGroupIds as $id) {
-                $rootGroups = $groupRepo->get($id)->getName();
+                $rootGroups[] = $groupRepo->get($id)->getName();
             }
         }
         

--- a/docs/API.md
+++ b/docs/API.md
@@ -265,7 +265,9 @@ Body:
     "groups": [
         201
     ],
-    "firstLevelGroupNames": "CH"
+    "firstLevelGroupNames": [
+        "CH"
+    ]
 }
 ```
 
@@ -541,7 +543,9 @@ Body:
                 201,
                 202
             ],
-            "firstLevelGroupNames": "ZH"
+            "firstLevelGroupNames": [
+                "ZH"
+            ]
         }
     ],
     "ratings": {
@@ -610,7 +614,9 @@ Body:
         201,
         202
     ],
-    "firstLevelGroupNames": "ZH"
+    "firstLevelGroupNames": [
+        "ZH"
+    ]
 }
 ```
 
@@ -836,7 +842,9 @@ Body:
             "groups": [
                 201
             ],
-            "firstLevelGroupNames": "CH"
+            "firstLevelGroupNames": [
+                "CH"
+            ]
         }
     "message": "OK"
 }
@@ -914,7 +922,9 @@ Body:
             201,
             202
         ],
-        "firstLevelGroupNames": "ZH"
+        "firstLevelGroupNames": [
+            "ZH"
+        ]
     }
 }
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -147,7 +147,9 @@ Body:
     "groups": [
         201
     ],
-    "firstLevelGroupNames": "CH"
+    "firstLevelGroupNames": [
+        "CH"
+    ]
 }
 ```
 

--- a/tests/Unit/Http/Controllers/RestApi/ApiHelperTest.php
+++ b/tests/Unit/Http/Controllers/RestApi/ApiHelperTest.php
@@ -58,7 +58,7 @@ class ApiHelperTest extends TestCase
         $this->assertArrayHasKey($this->someKey, $memberArray);
         $this->assertArrayNotHasKey($this->someAdminKey, $memberArray);
         $this->assertEquals($this->id, $memberArray['id']);
-        $this->assertEquals('Unit Group 1', $memberArray['firstLevelGroupNames']);
+        $this->assertContains('Unit Group 1', $memberArray['firstLevelGroupNames']);
     }
     
     private function getMember()


### PR DESCRIPTION
Found this while debugging the MailChimp service. For each member there was a maximum of one group synced as a tag. This fix allows syncing all the groups of a member.