### PR TITLE
Less duplicates

### DIFF
--- a/app/Repository/Member/MemberMatch.php
+++ b/app/Repository/Member/MemberMatch.php
@@ -366,7 +366,7 @@ class MemberMatch
     {
         foreach ($matches as $idx => $match) {
             if (!self::isShortNameOf($firstName, $match->firstName->getValue())
-                && !self::isShortNameOf($match->firstName->getValue(), $lastName)) {
+                && !self::isShortNameOf($match->firstName->getValue(), $firstName)) {
                 unset($matches[$idx]);
             }
             if (!self::isShortNameOf($lastName, $match->lastName->getValue())

--- a/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
+++ b/tests/Feature/Http/Controllers/RestApi/RestApiMemberTest.php
@@ -1143,6 +1143,9 @@ class RestApiMemberTest extends TestCase
             ],
             'lastName' => [
                 'value' => $member->lastName->getValue(),
+            ],
+            'email1' => [
+                'value' => $member->email1->getValue(),
             ]
         ];
         
@@ -1167,6 +1170,9 @@ class RestApiMemberTest extends TestCase
             ],
             'lastName' => [
                 'value' => $member->lastName->getValue(),
+            ],
+            'email1' => [
+                'value' => $member->email1->getValue(),
             ]
         ];
         
@@ -1182,7 +1188,8 @@ class RestApiMemberTest extends TestCase
     public function testPostMatch_200_ambiguous()
     {
         $member = $this->getMember(__METHOD__);
-        
+        $member->address1->setValue("Rue de l'Annonciade 22");
+
         $m = [
             'firstName' => [
                 'value' => $member->firstName->getValue(),
@@ -1190,6 +1197,9 @@ class RestApiMemberTest extends TestCase
             'lastName' => [
                 'value' => $member->lastName->getValue(),
             ],
+            'address1' => [
+                'value' => $member->address1->getValue(),
+            ]
         ];
         
         // precondition: assert we dont have any records with the same name


### PR DESCRIPTION
1. There is no need for a duplicate if we only have a name that matches: We can't do anything with it while comparing it manually to an existing entry. This is why we only create an ambiguous match if there is more information in the record.
The only exception to this is a typo in the mail address. However, bad mail addresses will be filtered after the first or second newsletter.

1. Match by phone number as well: If the phone number and the first name are the same, we return a match!

1. Fix a bug / typo https://github.com/grueneschweiz/weblingservice/blob/158fc931363a2eb5b7941f050d13c4be57e64ba1/app/Repository/Member/MemberMatch.php#L369

1. Remove unnecessary tabs

This part of the weblingservice is used by Avanti, Payrexxservice and the 2018 theme/forms. We better think twice if this doesn't break anything ;)